### PR TITLE
Check if theres input before throwing error

### DIFF
--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -286,8 +286,10 @@
             this.cancelBlur = true;
           }
         } else {
-          this._addTextToSuggestions(this.texts['invalid-format'].replace('%s',this.suggestionValue), this.cssClasses['invalid-format']);
-          this.cancelBlur = true;
+          if(val.length != 0) {
+            this._addTextToSuggestions(this.texts['invalid-format'].replace('%s',this.suggestionValue), this.cssClasses['invalid-format']);
+            this.cancelBlur = true;
+          }
         }
       }
     },


### PR DESCRIPTION
If a user does not input anything, the invalid-format error should not be shown.
