### PR TITLE
Fixes issue #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,22 @@ own function to query a database and return an array of suggestions. This functi
 
 Some events are fired:
 
+Note: All events are namespaced to `.tokens`
+
 ### `add`
 
 When an element is added this event is fired. Receives the value added as a parameter.
 
-### `remove`
+### `removed`
 
 When an element is removed, this event is fired. Receives the value removed as a parameter.
+
+Note: This was changed from `remove` to `removed` due to how jQuery handles trigger.
 
 ### `max`
 
 If you specify the `maxSelected` option to a value greater than `0', this event will be fired whenever you reach that
- ammount of tokens added.
+ amount of tokens added.
 
 ##Development
 

--- a/dist/tokens.js
+++ b/dist/tokens.js
@@ -1,9 +1,9 @@
 
 /*!
  * tokens - jQuery plugin that turns a text field into a tokenized autocomplete
- * v0.5.3
+ * v0.6.0
  * https://github.com/firstandthird/tokens/
- * copyright First + Third 2014
+ * copyright First + Third 2015
  * MIT License
 */
 /*!
@@ -469,7 +469,7 @@
       else if (this.allowAddingNoSuggestion){
         var val = $.trim(this.inputText.val());
         var isValid = this.validate(val);
-        
+
         if(typeof isValid === 'string') {
           val = isValid;
           isValid = true;
@@ -559,7 +559,7 @@
         this.currentValue.splice(index,1);
         this._updateValue();
 
-        this.emit('remove', text);
+        this.emit('remove.tokens', text);
       }
     },
     _addInitialValues : function(){
@@ -638,10 +638,10 @@
         list.insertBefore(this.listInputHolder);
         this._updateValue();
 
-        this.emit('add', value);
+        this.emit('add.tokens', value);
 
         if (this._hasReachedMax()){
-          this.emit('max', value);
+          this.emit('max.tokens', value);
         }
         return true;
       } else {

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -271,7 +271,7 @@
       else if (this.allowAddingNoSuggestion){
         var val = $.trim(this.inputText.val());
         var isValid = this.validate(val);
-        
+
         if(typeof isValid === 'string') {
           val = isValid;
           isValid = true;
@@ -361,7 +361,7 @@
         this.currentValue.splice(index,1);
         this._updateValue();
 
-        this.emit('remove', text);
+        this.emit('removed.tokens', text);
       }
     },
     _addInitialValues : function(){
@@ -440,10 +440,10 @@
         list.insertBefore(this.listInputHolder);
         this._updateValue();
 
-        this.emit('add', value);
+        this.emit('add.tokens', value);
 
         if (this._hasReachedMax()){
-          this.emit('max', value);
+          this.emit('max.tokens', value);
         }
         return true;
       } else {

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -96,7 +96,7 @@ suite('tokens', function() {
       test('should fire event passing value as parameter', function(){
         var car = 'Volkswagon';
 
-        tokens.on('add', function(e,value){
+        tokens.on('add.tokens', function(e,value){
           assert.equal(value,car);
         });
 
@@ -115,7 +115,7 @@ suite('tokens', function() {
           assert.notEqual(tokensFidel.getValue().length,2);
         });
         test('should fire an event on cap',function(done){
-          tokens.on('max',function(){
+          tokens.on('max.tokens',function(){
             done();
           });
           tokensFidel.addValue('Acura');
@@ -145,7 +145,7 @@ suite('tokens', function() {
       test('should fire event passing removed value as parameter', function(){
         var car = 'Acura';
 
-        tokens.on('remove', function(e,value){
+        tokens.on('removed.tokens', function(e,value){
           assert.equal(value,car);
         });
 


### PR DESCRIPTION
jQuery handles events from `.trigger` a bit interesting in that it checks if there's a matching method and runs it instead. Since `.remove` is a jQuery and a dom method, that took priority.

I've namespaced all events we trigger which will break any code that relies on it. It's the only way to make sure anything else funky doesn't happen.